### PR TITLE
Use old version of certbot/dns-simple

### DIFF
--- a/dnsimple/Dockerfile
+++ b/dnsimple/Dockerfile
@@ -1,2 +1,2 @@
-FROM certbot/dns-dnsimple
+FROM certbot/dns-dnsimple:v0.28.0
 COPY ./dnsimple.ini /opt/certbot


### PR DESCRIPTION
Looks like they just released a new version and now we're getting errors. Might be a coincidence but it also might not be.

https://hub.docker.com/r/certbot/dns-dnsimple/tags/