### PR TITLE
Allow usage of AWS environment credentials

### DIFF
--- a/bin/ssl.sh
+++ b/bin/ssl.sh
@@ -34,8 +34,10 @@ if [[ ! -d $CERT_DIR ]]; then
       -m $email \
       -d "$domains"
   elif [[ $dnsProvider == 'ROUTE_53' ]]; then
-    AWS_ACCESS_KEY_ID=$(aws --profile default configure get aws_access_key_id)
-    AWS_SECRET_ACCESS_KEY=$(aws --profile default configure get aws_secret_access_key)
+    if [ -z ${AWS_ACCESS_KEY_ID+x} ]; then
+      AWS_ACCESS_KEY_ID=$(aws --profile default configure get aws_access_key_id)
+      AWS_SECRET_ACCESS_KEY=$(aws --profile default configure get aws_secret_access_key)
+    fi
 
     docker build -t "wonqa-certbot" -f "route53/Dockerfile" .
     docker run -i --name wonqa-certbot \


### PR DESCRIPTION
**Goal:**  To allow the usage of the AWS SDK environment variables (_AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION_) instead of depending solely on the ~/.aws/credentials file.  This gives the implementer greater flexibility when working with automated deployments.

To accomplish this two files which were found to depend on the ~/.aws/credentials file were updated to make allowance for the presence of the env variables.   

I have tested automated deployments using both methods with this change with Github actions and the `create()` process appears to work as expected in both cases.
